### PR TITLE
Add optional Microsoft account (official) login

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v1.1.21
+	* Added Microsoft account login to play in online mode (optional)
+---------------------------------------------------------------------
 v1.1.20
 	* Fixed launching NeoForge and new Fabric versions
 	* Multithreaded downloading is enabled by default now

--- a/README.md
+++ b/README.md
@@ -16,6 +16,26 @@ Fast, lightweight and easy to use Minecraft launcher. Natively available for Win
 * Doesn't require Minecraft account
 * Doesn't require Java to work
 * Can work fully offline
+* Optional Microsoft account login for the official online mode
+
+---
+
+## Microsoft account (official online mode)
+
+The launcher works without an account by default. To play on online-mode
+servers, enable "Use Microsoft account (official)" in Settings and log in
+with a Microsoft account that owns Minecraft: Java Edition. The login uses
+the device code flow: the launcher shows a short code and a microsoft.com
+link where the code must be entered.
+
+This feature requires an Azure application client ID that Mojang has
+approved for the Minecraft services API. If the built-in ID is empty or
+rejected, a custom one can be set with the `MsaClientId` key in
+`vortex_launcher.conf`.
+
+Note: the Microsoft refresh token is stored in plain text in
+`vortex_launcher.conf`. Log out (Settings) before sharing that file or the
+launcher directory.
 
 ---
 

--- a/vlauncher_auth.pbi
+++ b/vlauncher_auth.pbi
@@ -1,0 +1,428 @@
+; Microsoft (official) account authentication for Vortex Launcher.
+;
+; Implements the OAuth 2.0 device code flow and the token chain required
+; by Minecraft: Java Edition:
+;   device code -> MSA token -> Xbox Live token -> XSTS token -> Minecraft token -> game profile
+;
+; The client ID must belong to an Azure application that Mojang has approved
+; for the Minecraft services API, otherwise login_with_xbox is rejected.
+; See https://help.minecraft.net/hc/en-us/articles/16254801392141
+; The ID can be overridden with the MsaClientId key in vortex_launcher.conf.
+
+#MsaClientIdDefault = ""
+#MsaScope = "XboxLive.signin offline_access"
+#MsaDeviceCodeUrl = "https://login.microsoftonline.com/consumers/oauth2/v2.0/devicecode"
+#MsaTokenUrl = "https://login.microsoftonline.com/consumers/oauth2/v2.0/token"
+#MsaXblAuthUrl = "https://user.auth.xboxlive.com/user/authenticate"
+#MsaXstsAuthUrl = "https://xsts.auth.xboxlive.com/xsts/authorize"
+#MsaMinecraftLoginUrl = "https://api.minecraftservices.com/authentication/login_with_xbox"
+#MsaMinecraftProfileUrl = "https://api.minecraftservices.com/minecraft/profile"
+
+Global.s msaPlayerName, msaUuid, msaAccessToken, msaXuid
+Global.s msaLastError
+Global.i msaHttpStatus
+
+Declare.s msaClientId()
+Declare.s msaHttpRequest(verb.i, url.s, body.s = "", contentType.s = "", bearer.s = "")
+Declare.s msaJsonString(jsonString.s, key.s)
+Declare.q msaJsonInteger(jsonString.s, key.s)
+Declare.s msaJwtPayload(jwt.s)
+Declare msaOpenBrowser(url.s)
+Declare.i msaXboxChain(msaToken.s)
+Declare.i msaEnsureLogin()
+Declare.i msaLoginInteractive()
+Declare msaLogout()
+Declare.s msaStatusText()
+
+Procedure.s msaClientId()
+  ProcedureReturn ReadPreferenceString("MsaClientId", #MsaClientIdDefault)
+EndProcedure
+
+Procedure.s msaHttpRequest(verb.i, url.s, body.s = "", contentType.s = "", bearer.s = "")
+  Protected NewMap headers.s()
+  Protected.i request
+  Protected.s response
+
+  headers("Accept") = "application/json"
+
+  If contentType <> ""
+    headers("Content-Type") = contentType
+  EndIf
+
+  If bearer <> ""
+    headers("Authorization") = "Bearer " + bearer
+  EndIf
+
+  msaHttpStatus = 0
+  request = HTTPRequest(verb, url, body, 0, headers())
+
+  If request
+    msaHttpStatus = Val(HTTPInfo(request, #PB_HTTP_StatusCode))
+    response = HTTPInfo(request, #PB_HTTP_Response)
+
+    FinishHTTP(request)
+  EndIf
+
+  ProcedureReturn response
+EndProcedure
+
+Procedure.s msaJsonString(jsonString.s, key.s)
+  Protected.i json, member
+  Protected.s value
+
+  json = ParseJSON(#PB_Any, jsonString)
+
+  If json
+    member = GetJSONMember(JSONValue(json), key)
+
+    If member And JSONType(member) = #PB_JSON_String
+      value = GetJSONString(member)
+    EndIf
+
+    FreeJSON(json)
+  EndIf
+
+  ProcedureReturn value
+EndProcedure
+
+Procedure.q msaJsonInteger(jsonString.s, key.s)
+  Protected.i json, member
+  Protected.q value
+
+  json = ParseJSON(#PB_Any, jsonString)
+
+  If json
+    member = GetJSONMember(JSONValue(json), key)
+
+    If member And JSONType(member) = #PB_JSON_Number
+      value = GetJSONInteger(member)
+    EndIf
+
+    FreeJSON(json)
+  EndIf
+
+  ProcedureReturn value
+EndProcedure
+
+Procedure.s msaJwtPayload(jwt.s)
+  Protected.s payload = StringField(jwt, 2, ".")
+  Protected.s decoded
+  Protected *buffer
+
+  payload = ReplaceString(payload, "-", "+")
+  payload = ReplaceString(payload, "_", "/")
+
+  While Len(payload) % 4
+    payload + "="
+  Wend
+
+  *buffer = AllocateMemory(Len(payload) + 1)
+
+  If *buffer
+    If Base64Decoder(payload, *buffer, MemorySize(*buffer) - 1)
+      decoded = PeekS(*buffer, -1, #PB_UTF8)
+    EndIf
+
+    FreeMemory(*buffer)
+  EndIf
+
+  ProcedureReturn decoded
+EndProcedure
+
+Procedure msaOpenBrowser(url.s)
+  CompilerSelect #PB_Compiler_OS
+    CompilerCase #PB_OS_Windows
+      RunProgram(url)
+    CompilerCase #PB_OS_Linux
+      RunProgram("xdg-open", url, "")
+    CompilerCase #PB_OS_MacOS
+      RunProgram("open", url, "")
+  CompilerEndSelect
+EndProcedure
+
+Procedure.i msaXboxChain(msaToken.s)
+  Protected.i requestJson, root, properties, userTokens, json, member, claims, xui
+  Protected.s requestBody, response, xblToken, userHash, xstsToken, jwtPayload
+  Protected.q xErr
+
+  ; Xbox Live authentication
+  requestJson = CreateJSON(#PB_Any)
+  root = SetJSONObject(JSONValue(requestJson))
+  properties = SetJSONObject(AddJSONMember(root, "Properties"))
+  SetJSONString(AddJSONMember(properties, "AuthMethod"), "RPS")
+  SetJSONString(AddJSONMember(properties, "SiteName"), "user.auth.xboxlive.com")
+  SetJSONString(AddJSONMember(properties, "RpsTicket"), "d=" + msaToken)
+  SetJSONString(AddJSONMember(root, "RelyingParty"), "http://auth.xboxlive.com")
+  SetJSONString(AddJSONMember(root, "TokenType"), "JWT")
+  requestBody = ComposeJSON(requestJson)
+  FreeJSON(requestJson)
+
+  response = msaHttpRequest(#PB_HTTP_Post, #MsaXblAuthUrl, requestBody, "application/json")
+
+  json = ParseJSON(#PB_Any, response)
+
+  If json
+    root = JSONValue(json)
+    member = GetJSONMember(root, "Token")
+
+    If member
+      xblToken = GetJSONString(member)
+    EndIf
+
+    claims = GetJSONMember(root, "DisplayClaims")
+
+    If claims
+      xui = GetJSONMember(claims, "xui")
+
+      If xui And JSONArraySize(xui) > 0
+        member = GetJSONMember(GetJSONElement(xui, 0), "uhs")
+
+        If member
+          userHash = GetJSONString(member)
+        EndIf
+      EndIf
+    EndIf
+
+    FreeJSON(json)
+  EndIf
+
+  If xblToken = "" Or userHash = ""
+    msaLastError = "Xbox Live authentication failed (HTTP " + Str(msaHttpStatus) + ")."
+    ProcedureReturn 0
+  EndIf
+
+  ; XSTS authorization
+  requestJson = CreateJSON(#PB_Any)
+  root = SetJSONObject(JSONValue(requestJson))
+  properties = SetJSONObject(AddJSONMember(root, "Properties"))
+  SetJSONString(AddJSONMember(properties, "SandboxId"), "RETAIL")
+  userTokens = SetJSONArray(AddJSONMember(properties, "UserTokens"))
+  SetJSONString(AddJSONElement(userTokens), xblToken)
+  SetJSONString(AddJSONMember(root, "RelyingParty"), "rp://api.minecraftservices.com/")
+  SetJSONString(AddJSONMember(root, "TokenType"), "JWT")
+  requestBody = ComposeJSON(requestJson)
+  FreeJSON(requestJson)
+
+  response = msaHttpRequest(#PB_HTTP_Post, #MsaXstsAuthUrl, requestBody, "application/json")
+  xstsToken = msaJsonString(response, "Token")
+
+  If xstsToken = ""
+    xErr = msaJsonInteger(response, "XErr")
+
+    If xErr = 2148916233
+      msaLastError = "This Microsoft account has no Xbox profile. Log in at xbox.com once to create it."
+    ElseIf xErr = 2148916238
+      msaLastError = "This is a child account. It must be added to a Microsoft family to play."
+    Else
+      msaLastError = "XSTS authorization failed (HTTP " + Str(msaHttpStatus) + ", XErr " + Str(xErr) + ")."
+    EndIf
+
+    ProcedureReturn 0
+  EndIf
+
+  ; Minecraft services login
+  requestJson = CreateJSON(#PB_Any)
+  root = SetJSONObject(JSONValue(requestJson))
+  SetJSONString(AddJSONMember(root, "identityToken"), "XBL3.0 x=" + userHash + ";" + xstsToken)
+  requestBody = ComposeJSON(requestJson)
+  FreeJSON(requestJson)
+
+  response = msaHttpRequest(#PB_HTTP_Post, #MsaMinecraftLoginUrl, requestBody, "application/json")
+  msaAccessToken = msaJsonString(response, "access_token")
+
+  If msaAccessToken = ""
+    msaLastError = "Minecraft login failed (HTTP " + Str(msaHttpStatus) + "). The launcher client ID may not be approved by Mojang."
+    ProcedureReturn 0
+  EndIf
+
+  ; auth_xuid is stored in the payload of the Minecraft access token
+  jwtPayload = msaJwtPayload(msaAccessToken)
+  msaXuid = msaJsonString(jwtPayload, "xuid")
+
+  If msaXuid = ""
+    msaXuid = "0000"
+  EndIf
+
+  ; Game profile (responds with 404 if the account doesn't own the game)
+  response = msaHttpRequest(#PB_HTTP_Get, #MsaMinecraftProfileUrl, "", "", msaAccessToken)
+  msaUuid = msaJsonString(response, "id")
+  msaPlayerName = msaJsonString(response, "name")
+
+  If msaUuid = "" Or msaPlayerName = ""
+    msaAccessToken = ""
+
+    If msaHttpStatus = 404
+      msaLastError = "This account does not own Minecraft: Java Edition."
+    Else
+      msaLastError = "Could not get the game profile (HTTP " + Str(msaHttpStatus) + ")."
+    EndIf
+
+    ProcedureReturn 0
+  EndIf
+
+  ProcedureReturn 1
+EndProcedure
+
+Procedure.i msaEnsureLogin()
+  Protected.s clientId = msaClientId()
+  Protected.s refreshToken = ReadPreferenceString("MsaRefreshToken", "")
+  Protected.s response, accessToken, newRefreshToken
+
+  msaLastError = ""
+
+  If msaAccessToken <> ""
+    ProcedureReturn 1
+  EndIf
+
+  If clientId = ""
+    msaLastError = "No Azure client ID is configured (MsaClientId in vortex_launcher.conf)."
+    ProcedureReturn 0
+  EndIf
+
+  If refreshToken = ""
+    msaLastError = "Not logged in. Use the Microsoft login button in Settings."
+    ProcedureReturn 0
+  EndIf
+
+  response = msaHttpRequest(#PB_HTTP_Post, #MsaTokenUrl, "grant_type=refresh_token&client_id=" + clientId + "&refresh_token=" + refreshToken + "&scope=" + URLEncoder(#MsaScope), "application/x-www-form-urlencoded")
+  accessToken = msaJsonString(response, "access_token")
+
+  If accessToken = ""
+    msaLastError = "The Microsoft session has expired (" + msaJsonString(response, "error") + "). Log in again in Settings."
+    ProcedureReturn 0
+  EndIf
+
+  newRefreshToken = msaJsonString(response, "refresh_token")
+
+  If newRefreshToken <> ""
+    WritePreferenceString("MsaRefreshToken", newRefreshToken)
+  EndIf
+
+  ProcedureReturn msaXboxChain(accessToken)
+EndProcedure
+
+Procedure.i msaLoginInteractive()
+  Protected.s clientId = msaClientId()
+  Protected.s response, deviceCode, userCode, verificationUri, oauthError, accessToken
+  Protected.i loginWindow, codeGadget, openBrowserButton, cancelButton
+  Protected.i event, interval, expiresIn, startTime, lastPoll, done, success
+
+  msaLastError = ""
+
+  If clientId = ""
+    MessageRequester("Error", "No Azure client ID is configured!" + #CRLF$ + #CRLF$ + "Microsoft login requires a Mojang-approved Azure client ID." + #CRLF$ + "It can be set with the MsaClientId key in vortex_launcher.conf.")
+    ProcedureReturn 0
+  EndIf
+
+  response = msaHttpRequest(#PB_HTTP_Post, #MsaDeviceCodeUrl, "client_id=" + clientId + "&scope=" + URLEncoder(#MsaScope), "application/x-www-form-urlencoded")
+
+  deviceCode = msaJsonString(response, "device_code")
+  userCode = msaJsonString(response, "user_code")
+  verificationUri = msaJsonString(response, "verification_uri")
+  interval = msaJsonInteger(response, "interval")
+  expiresIn = msaJsonInteger(response, "expires_in")
+
+  If deviceCode = ""
+    MessageRequester("Error", "Could not start the Microsoft login (HTTP " + Str(msaHttpStatus) + ")." + #CRLF$ + #CRLF$ + "Check your internet connection and the configured client ID.")
+    ProcedureReturn 0
+  EndIf
+
+  If interval < 1
+    interval = 5
+  EndIf
+
+  If expiresIn < 1
+    expiresIn = 900
+  EndIf
+
+  loginWindow = OpenWindow(#PB_Any, #PB_Ignore, #PB_Ignore, 320, 165, "Microsoft Login")
+
+  If loginWindow
+    TextGadget(#PB_Any, 5, 5, 310, 20, "1. Open " + verificationUri)
+    TextGadget(#PB_Any, 5, 25, 310, 20, "2. Enter this code:")
+    codeGadget = StringGadget(#PB_Any, 5, 45, 310, 25, userCode, #PB_String_ReadOnly)
+    TextGadget(#PB_Any, 5, 75, 310, 20, "3. Confirm the login in the browser and wait")
+    openBrowserButton = ButtonGadget(#PB_Any, 5, 100, 310, 27, "Copy code and open browser")
+    cancelButton = ButtonGadget(#PB_Any, 5, 132, 310, 27, "Cancel")
+
+    startTime = ElapsedMilliseconds()
+    lastPoll = ElapsedMilliseconds()
+
+    Repeat
+      event = WindowEvent()
+
+      If event = #PB_Event_Gadget
+        Select EventGadget()
+          Case openBrowserButton
+            SetClipboardText(userCode)
+            msaOpenBrowser(verificationUri)
+          Case cancelButton
+            done = 1
+        EndSelect
+      ElseIf event = #PB_Event_CloseWindow And EventWindow() = loginWindow
+        done = 1
+      ElseIf event = 0
+        Delay(50)
+      EndIf
+
+      If Not done And ElapsedMilliseconds() - lastPoll >= interval * 1000
+        lastPoll = ElapsedMilliseconds()
+
+        response = msaHttpRequest(#PB_HTTP_Post, #MsaTokenUrl, "grant_type=urn:ietf:params:oauth:grant-type:device_code&client_id=" + clientId + "&device_code=" + deviceCode, "application/x-www-form-urlencoded")
+
+        accessToken = msaJsonString(response, "access_token")
+        oauthError = msaJsonString(response, "error")
+
+        If accessToken <> ""
+          WritePreferenceString("MsaRefreshToken", msaJsonString(response, "refresh_token"))
+          success = msaXboxChain(accessToken)
+          done = 1
+        ElseIf oauthError = "slow_down"
+          interval + 5
+        ElseIf oauthError <> "authorization_pending"
+          msaLastError = "The login was not completed (" + oauthError + ")."
+          done = 1
+        EndIf
+      EndIf
+
+      If Not done And ElapsedMilliseconds() - startTime > expiresIn * 1000
+        msaLastError = "The login timed out."
+        done = 1
+      EndIf
+    Until done
+
+    CloseWindow(loginWindow)
+  EndIf
+
+  If success
+    WritePreferenceString("MsaPlayerName", msaPlayerName)
+  ElseIf msaLastError <> ""
+    MessageRequester("Error", "Microsoft login failed!" + #CRLF$ + #CRLF$ + msaLastError)
+  EndIf
+
+  ProcedureReturn success
+EndProcedure
+
+Procedure msaLogout()
+  RemovePreferenceKey("MsaRefreshToken")
+  RemovePreferenceKey("MsaPlayerName")
+
+  msaAccessToken = ""
+  msaPlayerName = ""
+  msaUuid = ""
+  msaXuid = ""
+EndProcedure
+
+Procedure.s msaStatusText()
+  Protected.s savedName = ReadPreferenceString("MsaPlayerName", "")
+
+  If ReadPreferenceString("MsaRefreshToken", "") <> ""
+    If savedName <> ""
+      ProcedureReturn "Account: " + savedName
+    EndIf
+
+    ProcedureReturn "Account: logged in"
+  EndIf
+
+  ProcedureReturn "Account: not logged in"
+EndProcedure

--- a/vlauncher_linux.pb
+++ b/vlauncher_linux.pb
@@ -27,6 +27,8 @@ Define.s uuid, jvmArguments, logConfId, logConfUrl, logConfArgument
 
 Define.i downloadThread, downloadMissingLibraries, jsonArgumentsMember, jsonArgumentsModernMember, jsonInheritsFromMember
 Define.i downloadMissingLibrariesGadget, downloadThreadsGadget, asyncDownloadGadget, saveSettingsButton, useCustomJavaGadget, useCustomParamsGadget, keepLauncherOpenGadget
+Define.i useMicrosoftAccountGadget, msaLoginButton, msaLogoutButton, msaStatusGadget, msaLaunchOk
+Define.s authAccessToken, authSession, authUserType, authXuid, authClientId
 Define.i i
 
 Define.s playerNameDefault = "PlayerName", ramAmountDefault = "2500", javaBinaryPathDefault = "/usr/bin/java"
@@ -41,8 +43,9 @@ Define.i saveLaunchStringDefault = 0
 Define.i useCustomJavaDefault = 0
 Define.i useCustomParamsDefault = 0
 Define.i keepLauncherOpenDefault = 0
+Define.i useMicrosoftAccountDefault = 0
 
-Define.s launcherVersion = "1.1.20"
+Define.s launcherVersion = "1.1.21"
 Define.s launcherDeveloper = "Kron4ek"
 
 Declare assetsToResources(assetsIndex.s)
@@ -56,6 +59,8 @@ Declare.s parseVersionsManifest(versionType.i = 0, getClientJarUrl.i = 0, client
 Declare.s parseLibraries(clientVersion.s, prepareForDownload.i = 0, librariesString.s = "")
 Declare.s fileRead(pathToFile.s)
 Declare.s removeSpacesFromVersionName(clientVersion.s)
+
+XIncludeFile "vlauncher_auth.pbi"
 
 SetCurrentDirectory(workingDirectory)
 workingDirectory = RTrim(GetCurrentDirectory(), "/")
@@ -291,6 +296,29 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
                   uuid = StringFingerprint("OfflinePlayer:" + playerName, #PB_Cipher_MD5)
                   uuid = Left(uuid, 12) + LCase(Hex(Val("$" + Mid(uuid, 13, 2)) & $0f | $30)) + Mid(uuid, 15, 2) + LCase(Hex(Val("$" + Mid(uuid, 17, 2)) & $3f | $80)) + Right(uuid, 14)
 
+                  authAccessToken = "00000000000000000000000000000000"
+                  authSession = "00000000000000000000000000000000"
+                  authUserType = "mojang"
+                  authXuid = "0000"
+                  authClientId = "0000"
+                  msaLaunchOk = 1
+
+                  If ReadPreferenceInteger("UseMicrosoftAccount", useMicrosoftAccountDefault)
+                    If msaEnsureLogin()
+                      playerName = msaPlayerName
+                      uuid = msaUuid
+                      authAccessToken = msaAccessToken
+                      authSession = "token:" + msaAccessToken + ":" + msaUuid
+                      authUserType = "msa"
+                      authXuid = msaXuid
+                      authClientId = msaClientId()
+                    Else
+                      msaLaunchOk = 0
+
+                      MessageRequester("Error", "Microsoft account login failed!" + #CRLF$ + #CRLF$ + msaLastError)
+                    EndIf
+                  EndIf
+
                   If assetsIndex = "pre-1.6" Or assetsIndex = "legacy"
                     assetsToResources(assetsIndex)
                   EndIf
@@ -320,14 +348,14 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
                   fullLaunchString = ReplaceString(fullLaunchString, "${game_directory}", Chr(34) + workingDirectory + Chr(34))
                   fullLaunchString = ReplaceString(fullLaunchString, "${assets_root}", "assets")
                   fullLaunchString = ReplaceString(fullLaunchString, "${auth_uuid}", uuid)
-                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_access_token}", "00000000000000000000000000000000")
-                  fullLaunchString = ReplaceString(fullLaunchString, "${clientid}", "0000")
-                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_xuid}", "0000")
+                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_access_token}", authAccessToken)
+                  fullLaunchString = ReplaceString(fullLaunchString, "${clientid}", authClientId)
+                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_xuid}", authXuid)
                   fullLaunchString = ReplaceString(fullLaunchString, "${user_properties}", "{}")
-                  fullLaunchString = ReplaceString(fullLaunchString, "${user_type}", "mojang")
+                  fullLaunchString = ReplaceString(fullLaunchString, "${user_type}", authUserType)
                   fullLaunchString = ReplaceString(fullLaunchString, "${version_type}", "release")
                   fullLaunchString = ReplaceString(fullLaunchString, "${assets_index_name}", assetsIndex)
-                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_session}", "00000000000000000000000000000000")
+                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_session}", authSession)
                   fullLaunchString = ReplaceString(fullLaunchString, "${game_assets}", "resources")
                   fullLaunchString = ReplaceString(fullLaunchString, "${classpath}", librariesString + clientJarFile)
                   fullLaunchString = ReplaceString(fullLaunchString, "${library_directory}", "libraries")
@@ -336,20 +364,22 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
                   fullLaunchString = ReplaceString(fullLaunchString, Chr(34) + "-Dminecraft.launcher.brand=${launcher_name}" + Chr(34), "")
                   fullLaunchString = ReplaceString(fullLaunchString, Chr(34) + "-Dminecraft.launcher.version=${launcher_version}" + Chr(34), "")
 
-                  RunProgram(javaBinaryPath, fullLaunchString, workingDirectory)
+                  If msaLaunchOk
+                    RunProgram(javaBinaryPath, fullLaunchString, workingDirectory)
 
-                  saveLaunchString = ReadPreferenceInteger("SaveLaunchString", saveLaunchStringDefault)
-                  If saveLaunchString
-                    DeleteFile("launch_string.txt")
+                    saveLaunchString = ReadPreferenceInteger("SaveLaunchString", saveLaunchStringDefault)
+                    If saveLaunchString
+                      DeleteFile("launch_string.txt")
 
-                    launchStringFile = OpenFile(#PB_Any, "launch_string.txt")
-                    fullLaunchString = ReplaceString(fullLaunchString, "  ", " ")
-                    WriteString(launchStringFile, Chr(34) + javaBinaryPath + Chr(34) + " " + fullLaunchString)
-                    CloseFile(launchStringFile)
-                  EndIf
+                      launchStringFile = OpenFile(#PB_Any, "launch_string.txt")
+                      fullLaunchString = ReplaceString(fullLaunchString, "  ", " ")
+                      WriteString(launchStringFile, Chr(34) + javaBinaryPath + Chr(34) + " " + fullLaunchString)
+                      CloseFile(launchStringFile)
+                    EndIf
 
-                  If Not ReadPreferenceInteger("KeepLauncherOpen", keepLauncherOpenDefault)
-                    Break
+                    If Not ReadPreferenceInteger("KeepLauncherOpen", keepLauncherOpenDefault)
+                      Break
+                    EndIf
                   EndIf
                 Else
                   MessageRequester("Error", "Client jar file is missing!")
@@ -479,7 +509,7 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
         Case settingsButton
           DisableGadget(settingsButton, 1)
 
-          If OpenWindow(3, #PB_Ignore, #PB_Ignore, 350, 315, "Vortex Launcher Settings")
+          If OpenWindow(3, #PB_Ignore, #PB_Ignore, 350, 365, "Vortex Launcher Settings")
               argsTextGadget = TextGadget(#PB_Any, 5, 5, 80, 30, "Launch parameters:")
               argsGadget = StringGadget(#PB_Any, 85, 5, 260, 30, ReadPreferenceString("LaunchArguments", customLaunchArgumentsDefault))
               GadgetToolTip(argsGadget, "These parameters will be used to launch Minecraft")
@@ -519,7 +549,15 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
               GadgetToolTip(keepLauncherOpenGadget, "Keep the launcher open after launching the game")
               SetGadgetState(keepLauncherOpenGadget, ReadPreferenceInteger("KeepLauncherOpen", keepLauncherOpenDefault))
 
-              saveSettingsButton = ButtonGadget(#PB_Any, 5, 275, 340, 20, "Save and apply")
+              useMicrosoftAccountGadget = CheckBoxGadget(#PB_Any, 5, 275, 340, 20, "Use Microsoft account (official)")
+              GadgetToolTip(useMicrosoftAccountGadget, "Log in with a Microsoft account that owns the game to play in online mode")
+              SetGadgetState(useMicrosoftAccountGadget, ReadPreferenceInteger("UseMicrosoftAccount", useMicrosoftAccountDefault))
+
+              msaStatusGadget = TextGadget(#PB_Any, 5, 303, 150, 20, msaStatusText())
+              msaLoginButton = ButtonGadget(#PB_Any, 160, 300, 90, 25, "Log in")
+              msaLogoutButton = ButtonGadget(#PB_Any, 255, 300, 90, 25, "Log out")
+
+              saveSettingsButton = ButtonGadget(#PB_Any, 5, 335, 340, 20, "Save and apply")
 
               DisableGadget(downloadThreadsGadget, Bool(Not GetGadgetState(asyncDownloadGadget)))
               DisableGadget(javaPathGadget, Bool(Not GetGadgetState(useCustomJavaGadget)))
@@ -531,6 +569,16 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
           DisableGadget(downloadThreadsGadget, Bool(Not GetGadgetState(asyncDownloadGadget)))
         Case useCustomJavaGadget
           DisableGadget(javaPathGadget, Bool(Not GetGadgetState(useCustomJavaGadget)))
+        Case msaLoginButton
+          If msaLoginInteractive()
+            MessageRequester("Microsoft Login", "Logged in as " + msaPlayerName)
+          EndIf
+
+          If IsGadget(msaStatusGadget) : SetGadgetText(msaStatusGadget, msaStatusText()) : EndIf
+        Case msaLogoutButton
+          msaLogout()
+
+          If IsGadget(msaStatusGadget) : SetGadgetText(msaStatusGadget, msaStatusText()) : EndIf
         Case saveSettingsButton
           If GetGadgetText(downloadThreadsGadget) = "0" : SetGadgetText(downloadThreadsGadget, "5") : EndIf
 
@@ -540,6 +588,7 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
           WritePreferenceInteger("UseCustomJava", GetGadgetState(useCustomJavaGadget))
           WritePreferenceInteger("UseCustomParameters", GetGadgetState(useCustomParamsGadget))
           WritePreferenceInteger("KeepLauncherOpen", GetGadgetState(keepLauncherOpenGadget))
+          WritePreferenceInteger("UseMicrosoftAccount", GetGadgetState(useMicrosoftAccountGadget))
 
           If GetGadgetState(useCustomJavaGadget)
             WritePreferenceString("JavaPath", GetGadgetText(javaPathGadget))

--- a/vlauncher_macos.pb
+++ b/vlauncher_macos.pb
@@ -27,6 +27,8 @@ Define.s uuid, jvmArguments, logConfId, logConfUrl, logConfArgument
 
 Define.i downloadThread, downloadMissingLibraries, jsonArgumentsMember, jsonArgumentsModernMember, jsonInheritsFromMember
 Define.i downloadMissingLibrariesGadget, downloadThreadsGadget, asyncDownloadGadget, saveSettingsButton, useCustomJavaGadget, useCustomParamsGadget, keepLauncherOpenGadget
+Define.i useMicrosoftAccountGadget, msaLoginButton, msaLogoutButton, msaStatusGadget, msaLaunchOk
+Define.s authAccessToken, authSession, authUserType, authXuid, authClientId
 Define.i i
 
 Define.s playerNameDefault = "Name", ramAmountDefault = "700", javaBinaryPathDefault = "/usr/bin/java"
@@ -41,6 +43,7 @@ Define.i saveLaunchStringDefault = 0
 Define.i useCustomJavaDefault = 0
 Define.i useCustomParamsDefault = 0
 Define.i keepLauncherOpenDefault = 0
+Define.i useMicrosoftAccountDefault = 0
 
 Define.s launcherVersion = "1.1.19"
 Define.s launcherDeveloper = "Kron4ek"
@@ -56,6 +59,8 @@ Declare.s parseVersionsManifest(versionType.i = 0, getClientJarUrl.i = 0, client
 Declare.s parseLibraries(clientVersion.s, prepareForDownload.i = 0)
 Declare.s fileRead(pathToFile.s)
 Declare.s removeSpacesFromVersionName(clientVersion.s)
+
+XIncludeFile "vlauncher_auth.pbi"
 
 If Not FileSize(workingDirectory) = -2
   CreateDirectory(workingDirectory)
@@ -298,6 +303,29 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
                   uuid = StringFingerprint("OfflinePlayer:" + playerName, #PB_Cipher_MD5)
                   uuid = Left(uuid, 12) + LCase(Hex(Val("$" + Mid(uuid, 13, 2)) & $0f | $30)) + Mid(uuid, 15, 2) + LCase(Hex(Val("$" + Mid(uuid, 17, 2)) & $3f | $80)) + Right(uuid, 14)
 
+                  authAccessToken = "00000000000000000000000000000000"
+                  authSession = "00000000000000000000000000000000"
+                  authUserType = "mojang"
+                  authXuid = "0000"
+                  authClientId = "0000"
+                  msaLaunchOk = 1
+
+                  If ReadPreferenceInteger("UseMicrosoftAccount", useMicrosoftAccountDefault)
+                    If msaEnsureLogin()
+                      playerName = msaPlayerName
+                      uuid = msaUuid
+                      authAccessToken = msaAccessToken
+                      authSession = "token:" + msaAccessToken + ":" + msaUuid
+                      authUserType = "msa"
+                      authXuid = msaXuid
+                      authClientId = msaClientId()
+                    Else
+                      msaLaunchOk = 0
+
+                      MessageRequester("Error", "Microsoft account login failed!" + #CRLF$ + #CRLF$ + msaLastError)
+                    EndIf
+                  EndIf
+
                   If assetsIndex = "pre-1.6" Or assetsIndex = "legacy"
                     assetsToResources(assetsIndex)
                   EndIf
@@ -327,14 +355,14 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
                   fullLaunchString = ReplaceString(fullLaunchString, "${game_directory}", Chr(34) + workingDirectory + Chr(34))
                   fullLaunchString = ReplaceString(fullLaunchString, "${assets_root}", "assets")
                   fullLaunchString = ReplaceString(fullLaunchString, "${auth_uuid}", uuid)
-                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_access_token}", "00000000000000000000000000000000")
-                  fullLaunchString = ReplaceString(fullLaunchString, "${clientid}", "0000")
-                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_xuid}", "0000")
+                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_access_token}", authAccessToken)
+                  fullLaunchString = ReplaceString(fullLaunchString, "${clientid}", authClientId)
+                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_xuid}", authXuid)
                   fullLaunchString = ReplaceString(fullLaunchString, "${user_properties}", "{}")
-                  fullLaunchString = ReplaceString(fullLaunchString, "${user_type}", "mojang")
+                  fullLaunchString = ReplaceString(fullLaunchString, "${user_type}", authUserType)
                   fullLaunchString = ReplaceString(fullLaunchString, "${version_type}", "release")
                   fullLaunchString = ReplaceString(fullLaunchString, "${assets_index_name}", assetsIndex)
-                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_session}", "00000000000000000000000000000000")
+                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_session}", authSession)
                   fullLaunchString = ReplaceString(fullLaunchString, "${game_assets}", "resources")
                   fullLaunchString = ReplaceString(fullLaunchString, "${classpath}", librariesString + clientJarFile)
                   fullLaunchString = ReplaceString(fullLaunchString, "${library_directory}", "libraries")
@@ -343,20 +371,22 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
                   fullLaunchString = ReplaceString(fullLaunchString, Chr(34) + "-Dminecraft.launcher.brand=${launcher_name}" + Chr(34), "")
                   fullLaunchString = ReplaceString(fullLaunchString, Chr(34) + "-Dminecraft.launcher.version=${launcher_version}" + Chr(34), "")
 
-                  RunProgram(javaBinaryPath, fullLaunchString, workingDirectory)
+                  If msaLaunchOk
+                    RunProgram(javaBinaryPath, fullLaunchString, workingDirectory)
 
-                  saveLaunchString = ReadPreferenceInteger("SaveLaunchString", saveLaunchStringDefault)
-                  If saveLaunchString
-                    DeleteFile("launch_string.txt")
+                    saveLaunchString = ReadPreferenceInteger("SaveLaunchString", saveLaunchStringDefault)
+                    If saveLaunchString
+                      DeleteFile("launch_string.txt")
 
-                    launchStringFile = OpenFile(#PB_Any, "launch_string.txt")
-                    fullLaunchString = ReplaceString(fullLaunchString, "  ", " ")
-                    WriteString(launchStringFile, Chr(34) + javaBinaryPath + Chr(34) + " " + fullLaunchString)
-                    CloseFile(launchStringFile)
-                  EndIf
+                      launchStringFile = OpenFile(#PB_Any, "launch_string.txt")
+                      fullLaunchString = ReplaceString(fullLaunchString, "  ", " ")
+                      WriteString(launchStringFile, Chr(34) + javaBinaryPath + Chr(34) + " " + fullLaunchString)
+                      CloseFile(launchStringFile)
+                    EndIf
 
-                  If Not ReadPreferenceInteger("KeepLauncherOpen", keepLauncherOpenDefault)
-                    Break
+                    If Not ReadPreferenceInteger("KeepLauncherOpen", keepLauncherOpenDefault)
+                      Break
+                    EndIf
                   EndIf
                 Else
                   MessageRequester("Error", "Client jar file is missing!")
@@ -488,7 +518,7 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
         Case settingsButton
           DisableGadget(settingsButton, 1)
 
-          If OpenWindow(3, #PB_Ignore, #PB_Ignore, 350, 315, "Vortex Launcher Settings")
+          If OpenWindow(3, #PB_Ignore, #PB_Ignore, 350, 365, "Vortex Launcher Settings")
               argsTextGadget = TextGadget(#PB_Any, 5, 5, 80, 30, "Launch parameters:")
               argsGadget = StringGadget(#PB_Any, 85, 5, 260, 30, ReadPreferenceString("LaunchArguments", customLaunchArgumentsDefault))
               GadgetToolTip(argsGadget, "These parameters will be used to launch Minecraft")
@@ -528,7 +558,15 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
               GadgetToolTip(keepLauncherOpenGadget, "Keep the launcher open after launching the game")
               SetGadgetState(keepLauncherOpenGadget, ReadPreferenceInteger("KeepLauncherOpen", keepLauncherOpenDefault))
 
-              saveSettingsButton = ButtonGadget(#PB_Any, 5, 275, 340, 20, "Save and apply")
+              useMicrosoftAccountGadget = CheckBoxGadget(#PB_Any, 5, 275, 340, 20, "Use Microsoft account (official)")
+              GadgetToolTip(useMicrosoftAccountGadget, "Log in with a Microsoft account that owns the game to play in online mode")
+              SetGadgetState(useMicrosoftAccountGadget, ReadPreferenceInteger("UseMicrosoftAccount", useMicrosoftAccountDefault))
+
+              msaStatusGadget = TextGadget(#PB_Any, 5, 303, 150, 20, msaStatusText())
+              msaLoginButton = ButtonGadget(#PB_Any, 160, 300, 90, 25, "Log in")
+              msaLogoutButton = ButtonGadget(#PB_Any, 255, 300, 90, 25, "Log out")
+
+              saveSettingsButton = ButtonGadget(#PB_Any, 5, 335, 340, 20, "Save and apply")
 
               DisableGadget(downloadThreadsGadget, Bool(Not GetGadgetState(asyncDownloadGadget)))
               DisableGadget(javaPathGadget, Bool(Not GetGadgetState(useCustomJavaGadget)))
@@ -544,6 +582,16 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
           DisableGadget(downloadThreadsGadget, Bool(Not GetGadgetState(asyncDownloadGadget)))
         Case useCustomJavaGadget
           DisableGadget(javaPathGadget, Bool(Not GetGadgetState(useCustomJavaGadget)))
+        Case msaLoginButton
+          If msaLoginInteractive()
+            MessageRequester("Microsoft Login", "Logged in as " + msaPlayerName)
+          EndIf
+
+          If IsGadget(msaStatusGadget) : SetGadgetText(msaStatusGadget, msaStatusText()) : EndIf
+        Case msaLogoutButton
+          msaLogout()
+
+          If IsGadget(msaStatusGadget) : SetGadgetText(msaStatusGadget, msaStatusText()) : EndIf
         Case saveSettingsButton
           If GetGadgetText(downloadThreadsGadget) = "0" : SetGadgetText(downloadThreadsGadget, "5") : EndIf
 
@@ -553,6 +601,7 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
           WritePreferenceInteger("UseCustomJava", GetGadgetState(useCustomJavaGadget))
           WritePreferenceInteger("UseCustomParameters", GetGadgetState(useCustomParamsGadget))
           WritePreferenceInteger("KeepLauncherOpen", GetGadgetState(keepLauncherOpenGadget))
+          WritePreferenceInteger("UseMicrosoftAccount", GetGadgetState(useMicrosoftAccountGadget))
 
           If GetGadgetState(useCustomJavaGadget)
             WritePreferenceString("JavaPath", GetGadgetText(javaPathGadget))

--- a/vlauncher_windows.pb
+++ b/vlauncher_windows.pb
@@ -30,6 +30,8 @@ Define.s uuid, jvmArguments, logConfId, logConfUrl, logConfArgument
 
 Define.i downloadMissingLibraries, jsonArgumentsMember, jsonArgumentsModernMember, jsonInheritsFromMember
 Define.i downloadMissingLibrariesGadget, downloadThreadsGadget, asyncDownloadGadget, saveSettingsButton, useCustomJavaGadget, useCustomParamsGadget, keepLauncherOpenGadget
+Define.i useMicrosoftAccountGadget, msaLoginButton, msaLogoutButton, msaStatusGadget, msaLaunchOk
+Define.s authAccessToken, authSession, authUserType, authXuid, authClientId
 Define.i i
 
 Define.s playerNameDefault = "PlayerName", ramAmountDefault = "2500"
@@ -43,10 +45,11 @@ Define.i versionsTypeDefault = 0
 Define.i saveLaunchStringDefault = 0
 Define.i useCustomParamsDefault = 0
 Define.i keepLauncherOpenDefault = 0
+Define.i useMicrosoftAccountDefault = 0
 Global.i useCustomJavaDefault = 0
 Global.s javaBinaryPathDefault = "C:\jre8\bin\javaw.exe"
 
-Define.s launcherVersion = "1.1.20"
+Define.s launcherVersion = "1.1.21"
 Define.s launcherDeveloper = "Kron4ek"
 
 Declare assetsToResources(assetsIndex.s)
@@ -61,6 +64,8 @@ Declare.s parseVersionsManifest(versionType.i = 0, getClientJarUrl.i = 0, client
 Declare.s parseLibraries(clientVersion.s, prepareForDownload.i = 0, librariesString.s = "")
 Declare.s fileRead(pathToFile.s)
 Declare.s removeSpacesFromVersionName(clientVersion.s)
+
+XIncludeFile "vlauncher_auth.pbi"
 
 programFilesDir(0) = GetEnvironmentVariable("ProgramW6432") + "\"
 programFilesDir(1) = GetEnvironmentVariable("PROGRAMFILES") + "\"
@@ -321,6 +326,29 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
                   uuid = StringFingerprint("OfflinePlayer:" + playerName, #PB_Cipher_MD5)
                   uuid = Left(uuid, 12) + LCase(Hex(Val("$" + Mid(uuid, 13, 2)) & $0f | $30)) + Mid(uuid, 15, 2) + LCase(Hex(Val("$" + Mid(uuid, 17, 2)) & $3f | $80)) + Right(uuid, 14)
 
+                  authAccessToken = "00000000000000000000000000000000"
+                  authSession = "00000000000000000000000000000000"
+                  authUserType = "mojang"
+                  authXuid = "0000"
+                  authClientId = "0000"
+                  msaLaunchOk = 1
+
+                  If ReadPreferenceInteger("UseMicrosoftAccount", useMicrosoftAccountDefault)
+                    If msaEnsureLogin()
+                      playerName = msaPlayerName
+                      uuid = msaUuid
+                      authAccessToken = msaAccessToken
+                      authSession = "token:" + msaAccessToken + ":" + msaUuid
+                      authUserType = "msa"
+                      authXuid = msaXuid
+                      authClientId = msaClientId()
+                    Else
+                      msaLaunchOk = 0
+
+                      MessageRequester("Error", "Microsoft account login failed!" + #CRLF$ + #CRLF$ + msaLastError)
+                    EndIf
+                  EndIf
+
                   If assetsIndex = "pre-1.6" Or assetsIndex = "legacy"
                     assetsToResources(assetsIndex)
                   EndIf
@@ -350,14 +378,14 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
                   fullLaunchString = ReplaceString(fullLaunchString, "${game_directory}", Chr(34) + workingDirectory + Chr(34))
                   fullLaunchString = ReplaceString(fullLaunchString, "${assets_root}", "assets")
                   fullLaunchString = ReplaceString(fullLaunchString, "${auth_uuid}", uuid)
-                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_access_token}", "00000000000000000000000000000000")
-                  fullLaunchString = ReplaceString(fullLaunchString, "${clientid}", "0000")
-                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_xuid}", "0000")
+                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_access_token}", authAccessToken)
+                  fullLaunchString = ReplaceString(fullLaunchString, "${clientid}", authClientId)
+                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_xuid}", authXuid)
                   fullLaunchString = ReplaceString(fullLaunchString, "${user_properties}", "{}")
-                  fullLaunchString = ReplaceString(fullLaunchString, "${user_type}", "mojang")
+                  fullLaunchString = ReplaceString(fullLaunchString, "${user_type}", authUserType)
                   fullLaunchString = ReplaceString(fullLaunchString, "${version_type}", "release")
                   fullLaunchString = ReplaceString(fullLaunchString, "${assets_index_name}", assetsIndex)
-                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_session}", "00000000000000000000000000000000")
+                  fullLaunchString = ReplaceString(fullLaunchString, "${auth_session}", authSession)
                   fullLaunchString = ReplaceString(fullLaunchString, "${game_assets}", "resources")
                   fullLaunchString = ReplaceString(fullLaunchString, "${classpath}", librariesString + clientJarFile)
                   fullLaunchString = ReplaceString(fullLaunchString, "${library_directory}", "libraries")
@@ -366,20 +394,22 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
                   fullLaunchString = ReplaceString(fullLaunchString, Chr(34) + "-Dminecraft.launcher.brand=${launcher_name}" + Chr(34), "")
                   fullLaunchString = ReplaceString(fullLaunchString, Chr(34) + "-Dminecraft.launcher.version=${launcher_version}" + Chr(34), "")
 
-                  RunProgram(javaBinaryPath, fullLaunchString, workingDirectory)
+                  If msaLaunchOk
+                    RunProgram(javaBinaryPath, fullLaunchString, workingDirectory)
 
-                  saveLaunchString = ReadPreferenceInteger("SaveLaunchString", saveLaunchStringDefault)
-                  If saveLaunchString
-                    DeleteFile("launch_string.txt")
+                    saveLaunchString = ReadPreferenceInteger("SaveLaunchString", saveLaunchStringDefault)
+                    If saveLaunchString
+                      DeleteFile("launch_string.txt")
 
-                    launchStringFile = OpenFile(#PB_Any, "launch_string.txt")
-                    fullLaunchString = ReplaceString(fullLaunchString, "  ", " ")
-                    WriteString(launchStringFile, Chr(34) + javaBinaryPath + Chr(34) + " " + fullLaunchString)
-                    CloseFile(launchStringFile)
-                  EndIf
+                      launchStringFile = OpenFile(#PB_Any, "launch_string.txt")
+                      fullLaunchString = ReplaceString(fullLaunchString, "  ", " ")
+                      WriteString(launchStringFile, Chr(34) + javaBinaryPath + Chr(34) + " " + fullLaunchString)
+                      CloseFile(launchStringFile)
+                    EndIf
 
-                  If Not ReadPreferenceInteger("KeepLauncherOpen", keepLauncherOpenDefault)
-                    Break
+                    If Not ReadPreferenceInteger("KeepLauncherOpen", keepLauncherOpenDefault)
+                      Break
+                    EndIf
                   EndIf
                 Else
                   MessageRequester("Error", "Client jar file is missing!")
@@ -509,7 +539,7 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
         Case settingsButton
           DisableGadget(settingsButton, 1)
 
-          If OpenWindow(3, #PB_Ignore, #PB_Ignore, 335, 255, "Vortex Launcher Settings")
+          If OpenWindow(3, #PB_Ignore, #PB_Ignore, 335, 305, "Vortex Launcher Settings")
               argsTextGadget = TextGadget(#PB_Any, 5, 5, 80, 30, "Launch parameters:")
               argsGadget = StringGadget(#PB_Any, 70, 5, 260, 25, ReadPreferenceString("LaunchArguments", customLaunchArgumentsDefault))
               GadgetToolTip(argsGadget, "These parameters will be used to launch Minecraft")
@@ -548,7 +578,15 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
               GadgetToolTip(keepLauncherOpenGadget, "Keep the launcher open after launching the game")
               SetGadgetState(keepLauncherOpenGadget, ReadPreferenceInteger("KeepLauncherOpen", keepLauncherOpenDefault))
 
-              saveSettingsButton = ButtonGadget(#PB_Any, 5, 220, 325, 30, "Save and apply")
+              useMicrosoftAccountGadget = CheckBoxGadget(#PB_Any, 5, 215, 300, 20, "Use Microsoft account (official)")
+              GadgetToolTip(useMicrosoftAccountGadget, "Log in with a Microsoft account that owns the game to play in online mode")
+              SetGadgetState(useMicrosoftAccountGadget, ReadPreferenceInteger("UseMicrosoftAccount", useMicrosoftAccountDefault))
+
+              msaStatusGadget = TextGadget(#PB_Any, 5, 244, 155, 20, msaStatusText())
+              msaLoginButton = ButtonGadget(#PB_Any, 165, 240, 80, 25, "Log in")
+              msaLogoutButton = ButtonGadget(#PB_Any, 250, 240, 80, 25, "Log out")
+
+              saveSettingsButton = ButtonGadget(#PB_Any, 5, 270, 325, 30, "Save and apply")
 
               DisableGadget(downloadThreadsGadget, Bool(Not GetGadgetState(asyncDownloadGadget)))
               DisableGadget(javaPathGadget, Bool(Not GetGadgetState(useCustomJavaGadget)))
@@ -560,6 +598,16 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
           DisableGadget(javaPathGadget, Bool(Not GetGadgetState(useCustomJavaGadget)))
         Case asyncDownloadGadget
           DisableGadget(downloadThreadsGadget, Bool(Not GetGadgetState(asyncDownloadGadget)))
+        Case msaLoginButton
+          If msaLoginInteractive()
+            MessageRequester("Microsoft Login", "Logged in as " + msaPlayerName)
+          EndIf
+
+          If IsGadget(msaStatusGadget) : SetGadgetText(msaStatusGadget, msaStatusText()) : EndIf
+        Case msaLogoutButton
+          msaLogout()
+
+          If IsGadget(msaStatusGadget) : SetGadgetText(msaStatusGadget, msaStatusText()) : EndIf
         Case saveSettingsButton
           If GetGadgetText(downloadThreadsGadget) = "0" : SetGadgetText(downloadThreadsGadget, "5") : EndIf
 
@@ -569,6 +617,7 @@ If OpenWindow(0, #PB_Ignore, #PB_Ignore, windowWidth, windowHeight, "Vortex Mine
           WritePreferenceInteger("UseCustomJava", GetGadgetState(useCustomJavaGadget))
           WritePreferenceInteger("UseCustomParameters", GetGadgetState(useCustomParamsGadget))
           WritePreferenceInteger("KeepLauncherOpen", GetGadgetState(keepLauncherOpenGadget))
+          WritePreferenceInteger("UseMicrosoftAccount", GetGadgetState(useMicrosoftAccountGadget))
 
           If GetGadgetState(useCustomJavaGadget)
             WritePreferenceString("JavaPath", GetGadgetText(javaPathGadget))


### PR DESCRIPTION
Implements the Microsoft account login requested in #46, as a fully optional mode. Offline launching stays the default and is unchanged.

## What it does

- New shared include `vlauncher_auth.pbi`, used by all three platform sources, implementing the official authentication chain: OAuth 2.0 device code flow -> MSA token -> Xbox Live -> XSTS -> `login_with_xbox` -> game profile.
- Settings window gains a "Use Microsoft account (official)" checkbox, an account status line, and Log in / Log out buttons. The login opens a small window with a code and a "Copy code and open browser" button, then waits for the confirmation at microsoft.com/link. No embedded browser is needed.
- When the mode is enabled, Play refreshes the session silently and substitutes the real access token, UUID, profile name, `auth_xuid` (decoded from the Minecraft JWT) and `user_type` `msa` into the launch string. If authentication fails, the game is not launched and the reason is shown (no Xbox profile, child account, does not own the game, expired session, etc.).
- The refresh token is stored in `vortex_launcher.conf` (plain text, same as other launchers store `accounts.json`; noted in the README).

## What I need from you

The chain only works with an Azure application client ID that Mojang has approved for the Minecraft services API (https://help.minecraft.net/hc/en-us/articles/16254801392141). Only the project owner can reasonably hold that registration, so:

- `#MsaClientIdDefault` in `vlauncher_auth.pbi` ships empty. Once you register an Azure app and get it approved, put the ID there.
- Until then, users can test with their own Azure app ID via the `MsaClientId` key in `vortex_launcher.conf`.
- Without an ID configured, the login button explains what is missing and everything else keeps working offline.

If you would rather not maintain this at all, feel free to close - I wrote it because #46 has been requested repeatedly (#76, #79, #88).

## Testing done

- `vlauncher_auth.pbi` compiles clean on PureBasic 6.40 (x64, Windows) and passes a runtime harness: JSON helpers, XErr values above 32 bit, JWT base64url payload decoding, and a live request to the Microsoft device code endpoint (returns the expected `unauthorized_client` OAuth error for an unregistered ID).
- The modified top-level blocks of all three `.pb` files compile on 6.40 with stubbed procedure bodies (the Free edition size limit prevents compiling the full files - please build with a licensed compiler before merging).
- Not yet tested: a complete login with an approved client ID and an account that owns the game. I am happy to run that end-to-end and fix whatever comes up once a client ID exists.

Unrelated note: `vlauncher_macos.pb` still calls `InitNetwork()` (removed in PureBasic 6.x), so the macOS source does not compile on current PureBasic with or without this change.
